### PR TITLE
Add missing token deletion functionality

### DIFF
--- a/server/auth/views.py
+++ b/server/auth/views.py
@@ -120,7 +120,8 @@ def invoke(token_param):
                     token.refresh = token.refresh - 1
                     db.session.commit()
                     return Responses.refresh()
-
+        else:
+            return Responses.not_exist()
     except Exception:
         return Responses.unauthorized()
 
@@ -138,6 +139,10 @@ def exhaust(token_param):
             if token.is_expired():
                 return Responses.expired()
             else:
+                db.session.delete(token)
+                db.session.commit()
                 return Responses.exhaust()
+        else:
+            return Responses.not_exist()
     except Exception:
         return Responses.unauthorized()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -194,6 +194,18 @@ class TestAuthBlueprint(BaseTestCase):
             self.assertTrue(response.content_type == "application/json")
             self.assertEqual(response.status_code, 200)
 
+            response = self.client.delete(
+                "/auth/" + auth_token,
+                headers={"X-API-Key": config["SECRET_KEY"]},
+                content_type="application/json",
+            )
+
+            data = json.loads(response.data)
+            self.assertEquals(data["status"], "fail")
+            self.assertEquals(data["message"], "Bad token")
+            self.assertTrue(response.content_type == "application/json")
+            self.assertEqual(response.status_code, 400)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Token deletion/nonexistent token checking was not implemented properly.
This PR adds:
- Token deletion
- Nonexistent token handling on `DELETE /auth/<token>` and `POST /auth/<token>/decrement`